### PR TITLE
Add EC2 edit support, instance cost justification, and UX improvements

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -134,6 +134,33 @@ locker_services:
   ## value of 'ip' variable for it.
   IP_TO_HOSTNAME_JS: 'hostname = "ipaddress-" + ip.replace(/\./g,"_") + ".example.com";'
 
+  ## Optional support email address.
+  ## When set, a "Get help" button appears in the bottom-right corner.
+  ## Remove or comment out to disable.
+  # support_email: "support@example.com"
+
+  ## Optional Jira Issue Collector buttons.
+  ## Each entry adds a button in the bottom-right corner that opens a Jira issue collector dialog.
+  ## Remove or comment out to disable (zero footprint when absent).
+  ##
+  ## Fields per collector:
+  ##   jira_url:      Base URL of your Jira instance (no trailing slash)
+  ##   collector_id:  The Jira issue collector ID (from Jira admin)
+  ##   label:         Button text
+  ##   icon:          CSS icon class (Font Awesome 4.7 or Glyphicons, e.g. "fa fa-bug")
+  ##   color:         CSS background-color (hex or named)
+  # jira_collectors:
+  #   - jira_url: "https://jira.example.com"
+  #     collector_id: "abc12345"
+  #     label: "Request a Feature"
+  #     icon: "fa fa-lightbulb-o"
+  #     color: "#0E3754"
+  #   - jira_url: "https://jira.example.com"
+  #     collector_id: "def67890"
+  #     label: "Report a Bug"
+  #     icon: "fa fa-bug"
+  #     color: "#ED1D24"
+
 # Manage settings for Locker
 locker:
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -86,6 +86,11 @@ locker_services:
     - 'i3.8xlarge'
     - 'm5n.24xlarge'
 
+  ## Maximum number of non-terminated EC2 servers a user can have at once.
+  ## Users at or above this limit will be blocked from creating new servers.
+  ## Admins (ADMIN_USERNAME) are exempt from this limit.
+  MAX_SERVERS_PER_USER: 3
+
   ## Extra tags that will be added to the tags of started EC2 instances
   ## as key-value pairs.
   ## Example:

--- a/config.example.yml
+++ b/config.example.yml
@@ -95,7 +95,7 @@ locker_services:
   ## for their instance type selection. Applies to all users including admins.
   LARGE_INSTANCE_COST_THRESHOLD: 2.0
 
-  ## Extra tags that will be added to the tags of started EC2 instances
+  ## Extra tags that will be added to the tags of started EC2 instances and their EBS volumes
   ## as key-value pairs.
   ## Example:
   ##    EXTRA_TAGS:

--- a/config.example.yml
+++ b/config.example.yml
@@ -91,6 +91,10 @@ locker_services:
   ## Admins (ADMIN_USERNAME) are exempt from this limit.
   MAX_SERVERS_PER_USER: 3
 
+  ## Cost threshold (USD/hr) above which users must provide justification
+  ## for their instance type selection. Applies to all users including admins.
+  LARGE_INSTANCE_COST_THRESHOLD: 2.0
+
   ## Extra tags that will be added to the tags of started EC2 instances
   ## as key-value pairs.
   ## Example:

--- a/locker_services/locker.cgi
+++ b/locker_services/locker.cgi
@@ -136,6 +136,17 @@ if 'edit_ec2_desc' in arguments:
    edit_ec2_desc = arguments['edit_ec2_desc'].value
 if 'edit_root_disk_size' in arguments:
    edit_root_disk_size = arguments['edit_root_disk_size'].value
+instance_type_justification = None
+if 'instance_type_justification' in arguments:
+   instance_type_justification = arguments['instance_type_justification'].value
+   if utils.empty(instance_type_justification):
+      instance_type_justification = None
+instance_type_price = None
+if 'instance_type_price' in arguments:
+   try:
+      instance_type_price = float(arguments['instance_type_price'].value)
+   except (ValueError, TypeError):
+      instance_type_price = None
 install_docker_flag = False
 if 'install_docker_cb' in arguments and arguments['install_docker_cb'].value == 'True':
    install_docker_flag = True
@@ -163,6 +174,31 @@ template = None
 #From Eric Sison: AMI ID's change frequently due to patching or bug fixes, search by AMI Name to find the latest AMI id; AMI Name: Amazon Linux 2 AG GPU latest
 ami_name = locker_config.AMI_NAME
 ami_id = utils.getAMIIDFromName(ami_name, aws_region='us-east-1')
+
+def validate_justification_if_needed(price, justification, config_btn=''):
+   """If instance type price exceeds threshold, require justification."""
+   threshold = getattr(locker_config, 'LARGE_INSTANCE_COST_THRESHOLD', 2.0)
+   if price is not None and price > threshold and (justification is None or justification.strip() == ''):
+      cgi_exit(
+         f"<b>Error</b>: Instance type costs ${price}/hr (threshold: ${threshold}/hr). "
+         f"A justification is required. Please go back and provide one.",
+         config_btn=config_btn
+      )
+
+def send_justification_email(smuser, instance_id, instance_type_str, justification, context='New'):
+   """Send email about large instance justification to the submitting user and admins."""
+   try:
+      html = (
+         f"<b>Large Instance Justification ({context})</b><br><br>"
+         f"<b>User:</b> {smuser}<br>"
+         f"<b>Instance ID:</b> {instance_id}<br>"
+         f"<b>Instance Type:</b> {instance_type_str}<br>"
+         f"<b>Justification:</b><br>{justification.strip()}"
+      )
+      utils.sendMailSMUser(locker_config.ADMIN_EMAIL_FROM,
+                           f'Large Instance Justification ({context}) - {instance_id}', html)
+   except:
+      pass
 
 def new_ec2_locker_func():
 
@@ -205,9 +241,10 @@ def new_ec2_locker_func():
       cgi_exit(startedFullMsg,config_btn='new_ec2_locker_btn')
    else:
       awsRegionsHash = utils.readJsonFile('aws_regions.json')
-      ec2InstanceTypesArr,instTypeNameToDesc = utils.getInstanceTypes(ami_id=ami_id)
+      ec2InstanceTypesArr,instTypeNameToDesc,instTypePrices = utils.getInstanceTypes(ami_id=ami_id)
       config = { 'aws_regions': awsRegionsHash, 'ec2_instance_types': ec2InstanceTypesArr, 'username': utils.getEnvVar(locker_config.SERVER_USER_ENV_VAR_NAME), 'devtest': devtest,
-                 'mount_network_homedir': locker_config.MOUNT_NETWORK_HOMEDIR_FLAG, 'container_user': locker_config.CONTAINER_USER }
+                 'mount_network_homedir': locker_config.MOUNT_NETWORK_HOMEDIR_FLAG, 'container_user': locker_config.CONTAINER_USER,
+                 'instance_type_prices': instTypePrices, 'large_instance_cost_threshold': getattr(locker_config, 'LARGE_INSTANCE_COST_THRESHOLD', 2.0) }
       template = env.get_template('new_ec2_locker.html')
 
    return(config, template)
@@ -405,6 +442,8 @@ def new_ec2_func(exec_exit=True):
                config_btn='new_ec2_btn'
             )
 
+      validate_justification_if_needed(instance_type_price, instance_type_justification, config_btn='new_ec2_btn')
+
       try:
 
          #See here: https://stackoverflow.com/questions/23929235/multi-line-string-with-extra-space-preserved-indentation
@@ -446,6 +485,13 @@ sudo mount -a
          username = locker_config.AMI_USER
          instanceid = resp['Instances'][0]['InstanceId']
 
+         if instance_type_justification is not None:
+            try:
+               utils.updateEc2Tags(instanceid, [{'Key': 'InstanceTypeJustification', 'Value': instance_type_justification.strip()}])
+            except:
+               pass
+            send_justification_email(smuser, instanceid, ec2_instance_type, instance_type_justification, context='New')
+
          remoteRes = utils.execRemoteCmd('bash',username,ip,sshprivkey=sshprivkey_docker_env_admin_key,stdinTxt=bashScriptTxt)
          lockerCgi = utils.getCGIScript()
          if not remoteRes['success']:
@@ -472,8 +518,9 @@ sudo mount -a
    else:
       awsRegionsHash = utils.readJsonFile('aws_regions.json')
 #      ec2InstanceTypesArr = utils.readJsonFile('ec2_instance_types.json')
-      ec2InstanceTypesArr,instTypeNameToDesc = utils.getInstanceTypes(ami_id=ami_id)
-      config = { 'aws_regions': awsRegionsHash, 'ec2_instance_types': ec2InstanceTypesArr, 'username': smuser, 'mount_network_homedir': locker_config.MOUNT_NETWORK_HOMEDIR_FLAG }
+      ec2InstanceTypesArr,instTypeNameToDesc,instTypePrices = utils.getInstanceTypes(ami_id=ami_id)
+      config = { 'aws_regions': awsRegionsHash, 'ec2_instance_types': ec2InstanceTypesArr, 'username': smuser, 'mount_network_homedir': locker_config.MOUNT_NETWORK_HOMEDIR_FLAG,
+                 'instance_type_prices': instTypePrices, 'large_instance_cost_threshold': getattr(locker_config, 'LARGE_INSTANCE_COST_THRESHOLD', 2.0) }
       template = env.get_template('new_ec2.html')
 
    return(config, template)
@@ -498,7 +545,7 @@ def ec2_portal_func(exec_exit=True):
          inst = utils.getLockerInstances()
       else:
          inst = utils.getLockerInstances(creator=smuser)
-      ec2InstanceTypesArr,instTypeNameToDesc = utils.getInstanceTypes(ami_id=ami_id)
+      ec2InstanceTypesArr,instTypeNameToDesc,_ = utils.getInstanceTypes(ami_id=ami_id)
       AWSTagsToHash(inst)
       if version_view == 'true':
          for currInst in inst:
@@ -690,6 +737,7 @@ def edit_ec2_instance_func():
 
       # Update instance type if changed
       if edit_ec2_instance_type is not None and not edit_ec2_instance_type.startswith(current_instance_type + ' ') and edit_ec2_instance_type != current_instance_type:
+         validate_justification_if_needed(instance_type_price, instance_type_justification, config_btn='ec2_portal_btn')
          if details['state'] == 'running':
             cgi_exit("<b>Error</b>: Instance must be stopped before changing instance type. Please <a href='locker.cgi?a=stop_ec2_instance&instance_id={}&instance_ip='>stop the instance</a> first.".format(instance_id), config_btn='ec2_portal_btn')
          # Extract the instance type name (e.g. "m5.xlarge" from "m5.xlarge (4 cores - 16 GB RAM, $0.2/Hrs)")
@@ -699,6 +747,9 @@ def edit_ec2_instance_func():
             cgi_exit("<b>Error</b> changing instance type: " + res['error_msg'], config_btn='ec2_portal_btn')
          # Update the InstanceTypeDescription tag
          utils.updateEc2Tags(instance_id, [{'Key': 'InstanceTypeDescription', 'Value': edit_ec2_instance_type}])
+         if instance_type_justification is not None:
+            utils.updateEc2Tags(instance_id, [{'Key': 'InstanceTypeJustification', 'Value': instance_type_justification.strip()}])
+            send_justification_email(smuser, instance_id, edit_ec2_instance_type, instance_type_justification, context='Edit')
          changes_made.append("Instance type changed to " + new_type_name)
 
       # Update storage if changed
@@ -718,7 +769,7 @@ def edit_ec2_instance_func():
          msg = "No changes were made.<br><a href='locker.cgi?a=ec2_portal'>Back to Server Portal</a>"
       cgi_exit(msg, config_btn='ec2_portal_btn')
    else:
-      ec2InstanceTypesArr,instTypeNameToDesc = utils.getInstanceTypes(ami_id=ami_id)
+      ec2InstanceTypesArr,instTypeNameToDesc,instTypePrices = utils.getInstanceTypes(ami_id=ami_id)
       config = {
          'instance_id': instance_id,
          'instance_ip': details['tags'].get('Hostname', ''),
@@ -727,7 +778,9 @@ def edit_ec2_instance_func():
          'current_desc': details['tags'].get('Description', ''),
          'current_root_disk_size': details['root_volume_size'] or 100,
          'ec2_instance_types': ec2InstanceTypesArr,
-         'username': smuser
+         'username': smuser,
+         'instance_type_prices': instTypePrices,
+         'large_instance_cost_threshold': getattr(locker_config, 'LARGE_INSTANCE_COST_THRESHOLD', 2.0)
       }
       template = env.get_template('edit_ec2.html')
 

--- a/locker_services/locker.cgi
+++ b/locker_services/locker.cgi
@@ -854,6 +854,13 @@ def cgi_exit(errormsg,config_btn=''):
             f"You have {len(non_terminated)} server(s) (limit is {max_servers}). "
             f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one."
          )
+   # Pass Jira issue collectors and support email config to template (if configured)
+   jira_collectors = getattr(locker_config, 'jira_collectors', None)
+   if jira_collectors:
+      config['jira_collectors'] = jira_collectors
+   support_email = getattr(locker_config, 'support_email', None)
+   if support_email:
+      config['support_email'] = support_email
    output = template.render(config=config)
    utils.printHTML(output)
    sys.exit()
@@ -899,6 +906,13 @@ if config is not None and template is not None:
             f"You have {len(non_terminated)} server(s) (limit is {max_servers}). "
             f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one."
          )
+   # Pass Jira issue collectors and support email config to template (if configured)
+   jira_collectors = getattr(locker_config, 'jira_collectors', None)
+   if jira_collectors:
+      config['jira_collectors'] = jira_collectors
+   support_email = getattr(locker_config, 'support_email', None)
+   if support_email:
+      config['support_email'] = support_email
 
 if template is not None:
    output = template.render(config=config)

--- a/locker_services/locker.cgi
+++ b/locker_services/locker.cgi
@@ -215,6 +215,9 @@ def new_ec2_locker_func():
    if stage == 'exec':
       (config,template) = new_ec2_func(exec_exit=False)
       startedEc2Msg = config['startedMsg']
+      ec2_instanceid = config['instanceid']
+      ec2_ip = config['ip']
+      ec2_remoteHostname = config['remoteHostname']
       server_username = config['instanceuser']
       hostname = config['remoteHostname']
       install_docker_flag = True
@@ -229,10 +232,23 @@ def new_ec2_locker_func():
       sshprivkey_locker = sshprivkey
       sshpubkey_locker = sshpubkey
       (config,template) = start_locker_image_func(exec_exit=False)
-      startedLockerMsg = config['startedLockerMsg']
-      startedLockerFullMsg = config['startedLockerFullMsg']
-      startedMsg = startedEc2Msg + "<br><br>" + startedLockerMsg
-      startedFullMsg = startedEc2Msg + "<br><br>" + startedLockerFullMsg
+      locker_remote_hostname = config['remote_hostname']
+      lockerCgi = utils.getCGIScript()
+      startedMsg = (
+         "<b>Your Locker server is ready!</b>"
+         "<br><br>"
+         "<b>Server:</b> {} ({})"
+         "<br>"
+         "<b>SSH:</b> {}@{}"
+         "<br><br>"
+         "<a href='https://{}' target='_blank'>Open Locker</a>"
+         " | "
+         "<a href='{}?a=ec2_portal'>Server Portal</a>"
+         " | "
+         "<a href='{}?a=terminate_ec2_instance&instance_id={}&instance_ip={}'>Terminate Server</a>"
+      ).format(ec2_remoteHostname, ec2_instanceid, locker_config.AMI_USER, ec2_ip,
+               locker_remote_hostname, lockerCgi, lockerCgi, ec2_instanceid, ec2_ip)
+      startedFullMsg = startedMsg + "<br><br>An email with these details has been sent to you."
       try:
          utils.sendMailSMUser(locker_config.ADMIN_EMAIL_FROM,'New EC2 started and Locker started on it',startedMsg)
       except:
@@ -401,8 +417,16 @@ def start_locker_image_func(exec_exit=True):
          json_formatted_res_str = json.dumps(startLocker_image_res, indent=2)
          cgi_exit("<b>Error</b>: failed starting Locker on remote server:<br><pre>" + json_formatted_res_str + "</pre>",config_btn='start_locker_image_btn')
 
-      startedLockerMsg = "<b>Success</b>: Locker was started on the remote server, access it <a href='https://{}'>here</a>.".format(remote_hostname)
-      startedLockerFullMsg = startedLockerMsg + "<br>You will also receive an email with this information."
+      startedLockerMsg = (
+         "<b>Locker is ready!</b>"
+         "<br><br>"
+         "Access your Locker at {}"
+         "<br><br>"
+         "<a href='https://{}' target='_blank'>Open Locker</a>"
+         " | "
+         "<a href='{}?a=ec2_portal'>Server Portal</a>"
+      ).format(remote_hostname, remote_hostname, utils.getCGIScript())
+      startedLockerFullMsg = startedLockerMsg + "<br><br>An email with these details has been sent to you."
 
       if exec_exit:
          try:
@@ -411,7 +435,7 @@ def start_locker_image_func(exec_exit=True):
             pass
          cgi_exit(startedLockerFullMsg,config_btn='start_locker_image_btn')
       else:
-         config = { 'startedLockerMsg': startedLockerMsg, 'startedLockerFullMsg': startedLockerFullMsg }
+         config = { 'startedLockerMsg': startedLockerMsg, 'startedLockerFullMsg': startedLockerFullMsg, 'remote_hostname': remote_hostname }
          return(config,None)
    else:
       template = env.get_template('start_locker_image.html')
@@ -500,8 +524,18 @@ sudo mount -a
             remoteRes = utils.execRemoteCmd('bash',username,ip,sshprivkey=sshprivkey_docker_env_admin_key,stdinTxt=bashScriptTxt2)
             if not remoteRes['success']:
                cgi_exit("<b>Error</b>: Failed adding user's priv key at remote server: " + remoteRes['error_msg'],config_btn="new_ec2_btn")
-         startedMsg = "Successfully started new EC2 with instance ID {}, access at {}@{} ({}).<br>Click <a href='{}?a=terminate_ec2_instance&instance_id={}&instance_ip={}'>here</a> to terminate this instance".format(instanceid, locker_config.AMI_USER, ip,remoteHostname,lockerCgi,instanceid,ip)
-         startedFullMsg = startedMsg + "<br>You will also receive an email with this information."
+         startedMsg = (
+            "<b>EC2 instance launched!</b>"
+            "<br><br>"
+            "<b>Server:</b> {} ({})"
+            "<br>"
+            "<b>SSH:</b> {}@{}"
+            "<br><br>"
+            "<a href='{}?a=ec2_portal'>Server Portal</a>"
+            " | "
+            "<a href='{}?a=terminate_ec2_instance&instance_id={}&instance_ip={}'>Terminate Server</a>"
+         ).format(remoteHostname, instanceid, locker_config.AMI_USER, ip, lockerCgi, lockerCgi, instanceid, ip)
+         startedFullMsg = startedMsg + "<br><br>An email with these details has been sent to you."
 
          if exec_exit:
             try:

--- a/locker_services/locker.cgi
+++ b/locker_services/locker.cgi
@@ -760,7 +760,25 @@ def edit_ec2_instance_func():
          if new_size > current_root_disk_size:
             res = utils.modifyEc2VolumeSize(details['root_volume_id'], new_size)
             if not res['success']:
-               cgi_exit("<b>Error</b> modifying volume size: " + res['error_msg'], config_btn='ec2_portal_btn')
+               error_msg = res['error_msg']
+               if 'IncorrectModificationState' in error_msg or 'OPTIMIZING' in error_msg:
+                  friendly = (
+                     "<b>Error modifying volume size</b>"
+                     "<br><br>"
+                     "This volume was recently resized and is still being optimized by AWS. "
+                     "AWS enforces a cooldown period (typically 6 hours) after each volume "
+                     "modification, during which no further size changes can be made."
+                     "<br><br>"
+                     "Please wait and try again later."
+                     "<br><br>"
+                     "<a style='cursor:pointer;' onclick='toggleShowHide(\"vol_error_details\");'>"
+                     "Show full error details <span id='vol_error_details_clickon'>&nbsp;+</span></a>"
+                     "<span style='display:none;' id='vol_error_details'>"
+                     "<br><br>" + error_msg +
+                     "</span>"
+                  )
+                  cgi_exit(friendly, config_btn='ec2_portal_btn')
+               cgi_exit("<b>Error</b> modifying volume size: " + error_msg, config_btn='ec2_portal_btn')
             changes_made.append("Root disk size changed to {} GB".format(new_size))
 
       if changes_made:

--- a/locker_services/locker.cgi
+++ b/locker_services/locker.cgi
@@ -392,6 +392,19 @@ def new_ec2_func(exec_exit=True):
    smuser = utils.getEnvVar(locker_config.SERVER_USER_ENV_VAR_NAME)
 
    if stage == 'exec':
+
+      # Check server limit
+      if smuser not in locker_config.ADMIN_USERNAME:
+         existing_instances = utils.getLockerInstances(creator=smuser)
+         non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
+         max_servers = locker_config.MAX_SERVERS_PER_USER
+         if len(non_terminated) >= max_servers:
+            cgi_exit(
+               f"<b>Error</b>: You already have {len(non_terminated)} server(s) (limit is {max_servers}). "
+               f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one.",
+               config_btn='new_ec2_btn'
+            )
+
       try:
 
          #See here: https://stackoverflow.com/questions/23929235/multi-line-string-with-extra-space-preserved-indentation
@@ -724,6 +737,18 @@ def cgi_exit(errormsg,config_btn=''):
    template = env.get_template('res_mesg.html')
    config['msg'] = errormsg
    config['config_btn'] = config_btn
+   # Check server limit for tab display (non-admin users only)
+   smuser_limit_check = utils.getEnvVar(locker_config.SERVER_USER_ENV_VAR_NAME)
+   if smuser_limit_check not in locker_config.ADMIN_USERNAME:
+      existing_instances = utils.getLockerInstances(creator=smuser_limit_check)
+      non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
+      max_servers = locker_config.MAX_SERVERS_PER_USER
+      if len(non_terminated) >= max_servers:
+         config['at_server_limit'] = True
+         config['server_limit_msg'] = (
+            f"You have {len(non_terminated)} server(s) (limit is {max_servers}). "
+            f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one."
+         )
    output = template.render(config=config)
    utils.printHTML(output)
    sys.exit()
@@ -755,6 +780,20 @@ elif a == 'update_locker':
 elif a == 'edit_ec2_instance':
    (config,template) = edit_ec2_instance_func()
 
+
+if config is not None and template is not None:
+   # Check server limit for tab display (non-admin users only)
+   smuser_limit_check = utils.getEnvVar(locker_config.SERVER_USER_ENV_VAR_NAME)
+   if smuser_limit_check not in locker_config.ADMIN_USERNAME:
+      existing_instances = utils.getLockerInstances(creator=smuser_limit_check)
+      non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
+      max_servers = locker_config.MAX_SERVERS_PER_USER
+      if len(non_terminated) >= max_servers:
+         config['at_server_limit'] = True
+         config['server_limit_msg'] = (
+            f"You have {len(non_terminated)} server(s) (limit is {max_servers}). "
+            f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one."
+         )
 
 if template is not None:
    output = template.render(config=config)

--- a/locker_services/locker.cgi
+++ b/locker_services/locker.cgi
@@ -127,6 +127,15 @@ if 'instance_ip' in arguments:
    instance_ip = arguments['instance_ip'].value
 if 'instance_hostname' in arguments:
    instance_hostname = arguments['instance_hostname'].value
+edit_ec2_instance_type = None
+edit_ec2_desc = None
+edit_root_disk_size = None
+if 'edit_ec2_instance_type' in arguments:
+   edit_ec2_instance_type = arguments['edit_ec2_instance_type'].value
+if 'edit_ec2_desc' in arguments:
+   edit_ec2_desc = arguments['edit_ec2_desc'].value
+if 'edit_root_disk_size' in arguments:
+   edit_root_disk_size = arguments['edit_root_disk_size'].value
 install_docker_flag = False
 if 'install_docker_cb' in arguments and arguments['install_docker_cb'].value == 'True':
    install_docker_flag = True
@@ -634,6 +643,83 @@ def update_locker_func():
    config['msg'] = f"<p>Please click <a onclick=\"if (confirm('Are you sure you want to update Locker on the instance?')) {{showSpinner(); window.location='locker.cgi?a=update_locker&stage=exec&instance_hostname={instance_hostname}&instance_ip={instance_ip}';}}\" href=\"#\">here</a> to update Locker on {instance_hostname} server with ip address {instance_ip}.</p>"
    return(config, template)
 
+def edit_ec2_instance_func():
+
+   config = {}
+   template = None
+   smuser = utils.getEnvVar(locker_config.SERVER_USER_ENV_VAR_NAME)
+
+   if utils.empty(instance_id):
+      cgi_exit("<b>Error</b>: No instance_id provided.", config_btn='ec2_portal_btn')
+
+   details = utils.getEc2InstanceDetails(instance_id)
+   if not details['success']:
+      cgi_exit("<b>Error</b>: " + details['error_msg'], config_btn='ec2_portal_btn')
+
+   # Authorization check
+   creator_tag = details['tags'].get('Creator', '')
+   creators = [x.strip() for x in creator_tag.split(",")]
+   if smuser not in creators and smuser not in locker_config.ADMIN_USERNAME:
+      cgi_exit("<b>Error</b>: You are not authorized to edit this instance because you are not its creator (or an admin).", config_btn='ec2_portal_btn')
+
+   if stage == 'exec':
+      changes_made = []
+      current_desc = details['tags'].get('Description', '')
+      current_instance_type = details['instance_type']
+      current_root_disk_size = details['root_volume_size']
+
+      # Update description if changed
+      if edit_ec2_desc is not None and edit_ec2_desc != current_desc:
+         res = utils.updateEc2Tags(instance_id, [{'Key': 'Description', 'Value': edit_ec2_desc}])
+         if not res['success']:
+            cgi_exit("<b>Error</b> updating description: " + res['error_msg'], config_btn='ec2_portal_btn')
+         changes_made.append("Description updated")
+
+      # Update instance type if changed
+      if edit_ec2_instance_type is not None and not edit_ec2_instance_type.startswith(current_instance_type + ' ') and edit_ec2_instance_type != current_instance_type:
+         if details['state'] == 'running':
+            cgi_exit("<b>Error</b>: Instance must be stopped before changing instance type. Please <a href='locker.cgi?a=stop_ec2_instance&instance_id={}&instance_ip='>stop the instance</a> first.".format(instance_id), config_btn='ec2_portal_btn')
+         # Extract the instance type name (e.g. "m5.xlarge" from "m5.xlarge (4 cores - 16 GB RAM, $0.2/Hrs)")
+         new_type_name = edit_ec2_instance_type.split(' ')[0] if ' ' in edit_ec2_instance_type else edit_ec2_instance_type
+         res = utils.modifyEc2InstanceType(instance_id, new_type_name)
+         if not res['success']:
+            cgi_exit("<b>Error</b> changing instance type: " + res['error_msg'], config_btn='ec2_portal_btn')
+         # Update the InstanceTypeDescription tag
+         utils.updateEc2Tags(instance_id, [{'Key': 'InstanceTypeDescription', 'Value': edit_ec2_instance_type}])
+         changes_made.append("Instance type changed to " + new_type_name)
+
+      # Update storage if changed
+      if edit_root_disk_size is not None and current_root_disk_size is not None:
+         new_size = int(edit_root_disk_size)
+         if new_size < current_root_disk_size:
+            cgi_exit("<b>Error</b>: Root disk size can only be increased, not decreased. Current size is {} GB.".format(current_root_disk_size), config_btn='ec2_portal_btn')
+         if new_size > current_root_disk_size:
+            res = utils.modifyEc2VolumeSize(details['root_volume_id'], new_size)
+            if not res['success']:
+               cgi_exit("<b>Error</b> modifying volume size: " + res['error_msg'], config_btn='ec2_portal_btn')
+            changes_made.append("Root disk size changed to {} GB".format(new_size))
+
+      if changes_made:
+         msg = "<b>Success</b>: " + "; ".join(changes_made) + ".<br><a href='locker.cgi?a=ec2_portal'>Back to Server Portal</a>"
+      else:
+         msg = "No changes were made.<br><a href='locker.cgi?a=ec2_portal'>Back to Server Portal</a>"
+      cgi_exit(msg, config_btn='ec2_portal_btn')
+   else:
+      ec2InstanceTypesArr,instTypeNameToDesc = utils.getInstanceTypes(ami_id=ami_id)
+      config = {
+         'instance_id': instance_id,
+         'instance_ip': details['tags'].get('Hostname', ''),
+         'instance_state': details['state'],
+         'current_instance_type': details['instance_type'],
+         'current_desc': details['tags'].get('Description', ''),
+         'current_root_disk_size': details['root_volume_size'] or 100,
+         'ec2_instance_types': ec2InstanceTypesArr,
+         'username': smuser
+      }
+      template = env.get_template('edit_ec2.html')
+
+   return(config, template)
+
 def cgi_exit(errormsg,config_btn=''):
    template = env.get_template('res_mesg.html')
    config['msg'] = errormsg
@@ -666,6 +752,8 @@ elif a == 'start_ec2_instance':
    (config,template) = start_ec2_instance_func()
 elif a == 'update_locker':
    (config,template) = update_locker_func()
+elif a == 'edit_ec2_instance':
+   (config,template) = edit_ec2_instance_func()
 
 
 if template is not None:

--- a/locker_services/templates/base.html
+++ b/locker_services/templates/base.html
@@ -171,6 +171,29 @@
 </div>
 {% endif %}
 
+{% if config.jira_collectors | default([]) or config.support_email | default('') %}
+<style>
+.support-bar { position: fixed; bottom: 12px; right: 16px; display: flex; align-items: center; gap: 6px; z-index: 1040; }
+.support-bar-link { font-size: 14px; cursor: pointer; text-decoration: none; opacity: 0.8; }
+.support-bar-link:hover { opacity: 1.0; text-decoration: underline; }
+.support-bar-sep { color: #999; font-size: 14px; }
+</style>
+<div class="support-bar">
+{% for collector in config.jira_collectors | default([]) %}
+{% if not loop.first %}<span class="support-bar-sep">|</span>{% endif %}
+<a id="jira-collector-{{ collector.collector_id }}" href="#" class="support-bar-link"
+   style="color: {{ collector.color }};"><i class="{{ collector.icon }}"></i> {{ collector.label }}</a>
+{% endfor %}
+{% if config.jira_collectors | default([]) and config.support_email | default('') %}
+<span class="support-bar-sep">|</span>
+{% endif %}
+{% if config.support_email | default('') %}
+<a href="mailto:{{ config.support_email }}" class="support-bar-link"
+   style="color: #17a2b8;"><i class="fa fa-question-circle"></i> Get help</a>
+{% endif %}
+</div>
+{% endif %}
+
   <!-- Optional JavaScript -->
   <!-- jQuery first, then Bootstrap JS, then jQuery bootgrid -->
   <script src="/static/jquery-1.11.1.min.js"></script>
@@ -240,6 +263,31 @@ function toggleOtherOptions() {
 }
 </script>
 
+{% if config.jira_collectors | default([]) %}
+<script>
+{% for collector in config.jira_collectors %}
+jQuery.ajax({
+    url: "{{ collector.jira_url }}/plugins/servlet/issueCollectorBootstrap.js?collectorId={{ collector.collector_id }}&locale=en_US",
+    type: "get",
+    cache: true,
+    dataType: "script"
+});
+{% endfor %}
+
+window.ATL_JQ_PAGE_PROPS = $.extend(window.ATL_JQ_PAGE_PROPS, {
+{% for collector in config.jira_collectors %}
+    '{{ collector.collector_id }}': {
+        "triggerFunction": function(showCollectorDialog) {
+            jQuery("#jira-collector-{{ collector.collector_id }}").click(function(e) {
+                e.preventDefault();
+                showCollectorDialog();
+            });
+        }
+    }{% if not loop.last %},{% endif %}
+{% endfor %}
+});
+</script>
+{% endif %}
 
 </body>
 

--- a/locker_services/templates/base.html
+++ b/locker_services/templates/base.html
@@ -146,8 +146,16 @@
       <!-- See here: https://stackoverflow.com/questions/12912048/how-to-maintain-aspect-ratio-using-html-img-tag -->
       <li><img class="locker_services_image" src="/static/logo_services.jpg" alt="Locker Services" style="max-width:64px;max-height:64px;width:auto;height:auto" onclick="document.location='locker.cgi';"></img></li>
       <li><a id="ec2_portal_btn" class="btn btn-primary" href="locker.cgi?a=ec2_portal">Locker Server Portal</a></li>&nbsp;&nbsp;
+      {% if config.at_server_limit | default(false) %}
+      <li style="cursor:not-allowed;"><a id="new_ec2_locker_btn" class="btn btn-primary disabled" title="Server limit reached">Locker on New Server</a></li>&nbsp;&nbsp;
+      {% else %}
       <li><a id="new_ec2_locker_btn" class="btn btn-primary" href="locker.cgi?a=new_ec2_locker">Locker on New Server</a></li>&nbsp;&nbsp;
+      {% endif %}
+      {% if config.at_server_limit | default(false) %}
+      <li style="cursor:not-allowed;"><a id="new_ec2_btn" style="display:none;" class="OTHER_OPTS btn btn-primary disabled" title="Server limit reached">New Server</a></li>&nbsp;&nbsp;
+      {% else %}
       <li><a id="new_ec2_btn" style="display:none;" class="OTHER_OPTS btn btn-primary" href="locker.cgi?a=new_ec2">New Server</a></li>&nbsp;&nbsp;
+      {% endif %}
       <li><a id="start_docker_btn" style="display:none;" class="OTHER_OPTS btn btn-primary" href="locker.cgi?a=start_docker">Check&sol;Start Docker</a></li>&nbsp;&nbsp;
       <li><a id="start_locker_image_btn" style="display:none;" class="OTHER_OPTS btn btn-primary" href="locker.cgi?a=start_locker_image">Start Locker</a></li>&nbsp;&nbsp;
       <li><a id="download_locker_btn" style="display:none;" class="OTHER_OPTS btn btn-primary" href="/download/">Download Locker&sol;Docs</a></li>&nbsp;&nbsp;
@@ -155,6 +163,13 @@
     </ul>
   </div>
 </nav>
+
+{% if config.at_server_limit | default(false) %}
+<div class="alert alert-warning alert-dismissible" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  <b>Server limit reached:</b> {{ config.server_limit_msg | safe }}
+</div>
+{% endif %}
 
   <!-- Optional JavaScript -->
   <!-- jQuery first, then Bootstrap JS, then jQuery bootgrid -->

--- a/locker_services/templates/ec2_portal.html
+++ b/locker_services/templates/ec2_portal.html
@@ -101,16 +101,17 @@
         },
         "actions": function (column, row) {
           var terminate_link = "locker.cgi?a=terminate_ec2_instance&instance_id=" + row.id + "&instance_ip=" + encodeURIComponent(row.ip)
+          var edit_link = "locker.cgi?a=edit_ec2_instance&instance_id=" + row.id
           if (row.state == 'running') {
             var stop_link = "locker.cgi?a=stop_ec2_instance&instance_id=" + row.id + "&instance_ip=" + encodeURIComponent(row.ip)
-            return "<a href='" + terminate_link + "'>Terminate</a>&nbsp;|&nbsp;<a href='" + stop_link + "'>Stop</a>";
+            return "<a href='" + edit_link + "'>Edit</a>&nbsp;|&nbsp;<a href='" + terminate_link + "'>Terminate</a>&nbsp;|&nbsp;<a href='" + stop_link + "'>Stop</a>";
           }
           else if (row.state == 'stopped') {
             var start_link = "locker.cgi?a=start_ec2_instance&instance_id=" + row.id + "&instance_ip=" + encodeURIComponent(row.ip)
-            return "<a href='" + terminate_link + "'>Terminate</a>&nbsp;|&nbsp;<a href='" + start_link + "'>Restart</a>";
+            return "<a href='" + edit_link + "'>Edit</a>&nbsp;|&nbsp;<a href='" + terminate_link + "'>Terminate</a>&nbsp;|&nbsp;<a href='" + start_link + "'>Restart</a>";
           }
           else if (row.state != 'terminated') {
-            return "<a href='" + terminate_link + "'>Terminate</a>";
+            return "<a href='" + edit_link + "'>Edit</a>&nbsp;|&nbsp;<a href='" + terminate_link + "'>Terminate</a>";
           }
         },
         "open_connection": function (column, row) {

--- a/locker_services/templates/ec2_portal.html
+++ b/locker_services/templates/ec2_portal.html
@@ -123,7 +123,7 @@
             }
             var locker_link = "https://" + hostname;
             var ssh_link = "ssh://{{ config.ami_user }}@" + row.ip;
-            return "<a href='" + locker_link + "'>Locker</a>&nbsp;|&nbsp;<a title='Note that this SSH link will only work on Mac/Linux and not on Windows. On Windows you will need to configure an SSH client such as PuTTY to SSH to the server at: {{ config.ami_user }}@" + row.ip + " and use your specified SSH private key (password login not supported).' href='" + ssh_link + "'>SSH</a>";
+            return "<a href='" + locker_link + "' target='_blank'>Locker</a>&nbsp;|&nbsp;<a title='Note that this SSH link will only work on Mac/Linux and not on Windows. On Windows you will need to configure an SSH client such as PuTTY to SSH to the server at: {{ config.ami_user }}@" + row.ip + " and use your specified SSH private key (password login not supported).' href='" + ssh_link + "' target='_blank'>SSH</a>";
           }
           else {
             return "&nbsp;"

--- a/locker_services/templates/edit_ec2.html
+++ b/locker_services/templates/edit_ec2.html
@@ -38,6 +38,17 @@
     </SELECT>
     {% endif %}
   </div>
+  <div class="form-group" id="justification_group" style="display:none;">
+    <label id="instance_type_justification_label" style="color:#cc0000;">
+      <span class="glyphicon glyphicon-exclamation-sign"></span>
+      This instance type costs more than ${{ config.large_instance_cost_threshold }}/hr.
+      Please provide a justification:
+    </label>
+    <textarea id="instance_type_justification" name="instance_type_justification"
+              class="form-control" rows="3"
+              placeholder="Explain why this instance type is needed..."></textarea>
+  </div>
+  <input type="hidden" name="instance_type_price" id="instance_type_price" value="" />
   <div class="form-group">
     <label id="edit_ec2_desc_label">Description:</label>
     <input type="text" class="form-control" name="edit_ec2_desc" id="edit_ec2_desc" value="{{ config.current_desc }}"></input>
@@ -56,6 +67,29 @@
 
 <script>
 
+var LARGE_INSTANCE_COST_THRESHOLD = {{ config.large_instance_cost_threshold }};
+var INSTANCE_TYPE_PRICES = {{ config.instance_type_prices | tojson }};
+var CURRENT_INSTANCE_TYPE = "{{ config.current_instance_type }}";
+
+function getInstanceTypeName(instTypeStr) {
+   return instTypeStr ? instTypeStr.split(' ')[0] : null;
+}
+
+function checkInstanceTypeJustification() {
+   var selectedVal = $('#edit_ec2_instance_type').val();
+   var typeName = getInstanceTypeName(selectedVal);
+   var isChanging = typeName !== CURRENT_INSTANCE_TYPE;
+   var price = (typeName && INSTANCE_TYPE_PRICES[typeName] !== undefined) ? INSTANCE_TYPE_PRICES[typeName] : null;
+   $('#instance_type_price').val(price !== null ? price : '');
+   if (isChanging && price !== null && price > LARGE_INSTANCE_COST_THRESHOLD) {
+      $('#justification_group').show();
+      $('#instance_type_justification').attr('required', 'required');
+   } else {
+      $('#justification_group').hide();
+      $('#instance_type_justification').removeAttr('required').val('');
+   }
+}
+
 $(document).ready(function(){
 
    $("a.root_disk_size_tooltipLink").tooltip();
@@ -63,6 +97,11 @@ $(document).ready(function(){
    setPageButton('ec2_portal_btn');
 
    $("#edit_ec2_instance_type").select2();
+
+   checkInstanceTypeJustification();
+   $('#edit_ec2_instance_type').on('change', function() {
+      checkInstanceTypeJustification();
+   });
 
    // Client-side validation: storage can only increase
    var currentSize = {{ config.current_root_disk_size }};

--- a/locker_services/templates/edit_ec2.html
+++ b/locker_services/templates/edit_ec2.html
@@ -1,0 +1,82 @@
+{% extends 'base.html' %}
+
+{% block title %}Edit EC2 Instance{% endblock %}
+
+{% block main %}
+
+<center><h3>Edit EC2 Instance {{ config.instance_id }}</h3></center>
+
+{% if config.instance_state == 'running' %}
+<div class="alert alert-warning">
+  <strong>Note:</strong> This instance is currently running. To change the instance type, you must first <a href="locker.cgi?a=stop_ec2_instance&instance_id={{ config.instance_id }}&instance_ip={{ config.instance_ip }}">stop the instance</a>.
+</div>
+{% endif %}
+
+<form action="locker.cgi" method=POST enctype="multipart/form-data" onsubmit="showSpinner();" id="edit_ec2_form">
+  <div class="form-group">
+    <label id="edit_ec2_instance_type_label">Instance Type:</label> (<a href="https://aws.amazon.com/ec2/instance-types/" target=_NEW>more details</a>)
+    {% if config.instance_state == 'running' %}
+    <SELECT class="form-control" name="edit_ec2_instance_type_disabled" id="edit_ec2_instance_type" disabled>
+      {% for instType in config.ec2_instance_types %}
+      {% if instType.startswith('---') %}
+      <OPTION value="{{instType}}" disabled>{{instType}}</option>
+      {% else %}
+      <OPTION value="{{instType}}" {{ 'selected' if instType.startswith(config.current_instance_type + ' ') or instType == config.current_instance_type else '' }}>{{instType}}</option>
+      {% endif %}
+      {% endfor %}
+    </SELECT>
+    <input type="hidden" name="edit_ec2_instance_type" value="{{ config.current_instance_type }}" />
+    {% else %}
+    <SELECT class="form-control" name="edit_ec2_instance_type" id="edit_ec2_instance_type">
+      {% for instType in config.ec2_instance_types %}
+      {% if instType.startswith('---') %}
+      <OPTION value="{{instType}}" disabled>{{instType}}</option>
+      {% else %}
+      <OPTION value="{{instType}}" {{ 'selected' if instType.startswith(config.current_instance_type + ' ') or instType == config.current_instance_type else '' }}>{{instType}}</option>
+      {% endif %}
+      {% endfor %}
+    </SELECT>
+    {% endif %}
+  </div>
+  <div class="form-group">
+    <label id="edit_ec2_desc_label">Description:</label>
+    <input type="text" class="form-control" name="edit_ec2_desc" id="edit_ec2_desc" value="{{ config.current_desc }}"></input>
+  </div>
+  <div class="form-group">
+    <label id="edit_root_disk_size_label">Root Disk Size in GB:</label>
+    <a data-toggle="tooltip" class="root_disk_size_tooltipLink" title="Disk size can only be increased, not decreased. After a size change, AWS enforces a 6-hour cooldown before another modification can be made."><span class="glyphicon glyphicon-info-sign"></span></a>
+    <input type="number" min="{{ config.current_root_disk_size }}" max="1000" class="form-control" name="edit_root_disk_size" id="edit_root_disk_size" value="{{ config.current_root_disk_size }}"></input>
+  </div>
+  <input type="hidden" name="a" value="edit_ec2_instance" />
+  <input type="hidden" name="stage" value="exec" />
+  <input type="hidden" name="instance_id" value="{{ config.instance_id }}" />
+  <button type="submit" class="btn btn-default" name="save_changes" id="save_changes" value="set">Save Changes</button>
+  <a class="btn btn-default" href="locker.cgi?a=ec2_portal">Cancel</a>
+</form>
+
+<script>
+
+$(document).ready(function(){
+
+   $("a.root_disk_size_tooltipLink").tooltip();
+
+   setPageButton('ec2_portal_btn');
+
+   $("#edit_ec2_instance_type").select2();
+
+   // Client-side validation: storage can only increase
+   var currentSize = {{ config.current_root_disk_size }};
+   $("#edit_ec2_form").on("submit", function(e) {
+      var newSize = parseInt($("#edit_root_disk_size").val());
+      if (newSize < currentSize) {
+         e.preventDefault();
+         alert("Root disk size can only be increased, not decreased. Current size is " + currentSize + " GB.");
+         return false;
+      }
+   });
+
+});
+
+</script>
+
+{% endblock %}

--- a/locker_services/templates/new_ec2.html
+++ b/locker_services/templates/new_ec2.html
@@ -35,6 +35,17 @@
       {% endfor %}
     </SELECT>
   </div>
+  <div class="form-group" id="justification_group" style="display:none;">
+    <label id="instance_type_justification_label" style="color:#cc0000;">
+      <span class="glyphicon glyphicon-exclamation-sign"></span>
+      This instance type costs more than ${{ config.large_instance_cost_threshold }}/hr.
+      Please provide a justification:
+    </label>
+    <textarea id="instance_type_justification" name="instance_type_justification"
+              class="form-control" rows="3"
+              placeholder="Explain why this instance type is needed..."></textarea>
+  </div>
+  <input type="hidden" name="instance_type_price" id="instance_type_price" value="" />
   <div class="form-group">
     <label id="config_ec2_desc_label">Description (i.e. an optional note to describe what you will use this server for):</label>
     <input type="text" class="form-control" name="config_ec2_desc" id="config_ec2_desc" value=""></input>
@@ -70,6 +81,27 @@
 
 <script>
 
+var LARGE_INSTANCE_COST_THRESHOLD = {{ config.large_instance_cost_threshold }};
+var INSTANCE_TYPE_PRICES = {{ config.instance_type_prices | tojson }};
+
+function getInstanceTypeName(instTypeStr) {
+   return instTypeStr ? instTypeStr.split(' ')[0] : null;
+}
+
+function checkInstanceTypeJustification() {
+   var selectedVal = $('#config_ec2_instance_type').val();
+   var typeName = getInstanceTypeName(selectedVal);
+   var price = (typeName && INSTANCE_TYPE_PRICES[typeName] !== undefined) ? INSTANCE_TYPE_PRICES[typeName] : null;
+   $('#instance_type_price').val(price !== null ? price : '');
+   if (price !== null && price > LARGE_INSTANCE_COST_THRESHOLD) {
+      $('#justification_group').show();
+      $('#instance_type_justification').attr('required', 'required');
+   } else {
+      $('#justification_group').hide();
+      $('#instance_type_justification').removeAttr('required').val('');
+   }
+}
+
 function isEmpty(property) {
       return (property === null || property.trim() === "" || typeof property === "undefined");
    }
@@ -85,6 +117,11 @@ $(document).ready(function(){
 
    $("#config_aws_region").select2();
    $("#config_ec2_instance_type").select2();
+
+   checkInstanceTypeJustification();
+   $('#config_ec2_instance_type').on('change', function() {
+      checkInstanceTypeJustification();
+   });
 
 });
 

--- a/locker_services/templates/new_ec2_locker.html
+++ b/locker_services/templates/new_ec2_locker.html
@@ -34,6 +34,17 @@
       {% endfor %}
     </SELECT>
   </div>
+  <div class="form-group" id="justification_group" style="display:none;">
+    <label id="instance_type_justification_label" style="color:#cc0000;">
+      <span class="glyphicon glyphicon-exclamation-sign"></span>
+      This instance type costs more than ${{ config.large_instance_cost_threshold }}/hr.
+      Please provide a justification:
+    </label>
+    <textarea id="instance_type_justification" name="instance_type_justification"
+              class="form-control" rows="3"
+              placeholder="Explain why this instance type is needed..."></textarea>
+  </div>
+  <input type="hidden" name="instance_type_price" id="instance_type_price" value="" />
   <div class="form-group">
     <label id="config_ec2_desc_label">Description (i.e. an optional note to describe what you will use this server for):</label>
     <input type="text" class="form-control" name="config_ec2_desc" id="config_ec2_desc" value=""></input>
@@ -74,6 +85,27 @@
 
 <script>
 
+var LARGE_INSTANCE_COST_THRESHOLD = {{ config.large_instance_cost_threshold }};
+var INSTANCE_TYPE_PRICES = {{ config.instance_type_prices | tojson }};
+
+function getInstanceTypeName(instTypeStr) {
+   return instTypeStr ? instTypeStr.split(' ')[0] : null;
+}
+
+function checkInstanceTypeJustification() {
+   var selectedVal = $('#config_ec2_instance_type').val();
+   var typeName = getInstanceTypeName(selectedVal);
+   var price = (typeName && INSTANCE_TYPE_PRICES[typeName] !== undefined) ? INSTANCE_TYPE_PRICES[typeName] : null;
+   $('#instance_type_price').val(price !== null ? price : '');
+   if (price !== null && price > LARGE_INSTANCE_COST_THRESHOLD) {
+      $('#justification_group').show();
+      $('#instance_type_justification').attr('required', 'required');
+   } else {
+      $('#justification_group').hide();
+      $('#instance_type_justification').removeAttr('required').val('');
+   }
+}
+
 function isEmpty(property) {
       return (property === null || property.trim() === "" || typeof property === "undefined");
    }
@@ -89,6 +121,11 @@ $(document).ready(function(){
 
    $("#config_aws_region").select2();
    $("#config_ec2_instance_type").select2();
+
+   checkInstanceTypeJustification();
+   $('#config_ec2_instance_type').on('change', function() {
+      checkInstanceTypeJustification();
+   });
 
 });
 

--- a/locker_services/utils.py
+++ b/locker_services/utils.py
@@ -918,7 +918,6 @@ def sendMailSMUser(fromEmail,subj,msgHtml):
         http_smuser_email = queryLdapForUid(http_smuser)
         if http_smuser_email is not None:
             toList = [http_smuser_email] + toList
-
     sendMail(fromEmail,toList,subj,msgHtml)
     return
 
@@ -948,7 +947,7 @@ def sendMail(fromEmail,toList,subj,msgHtml):
     mail.ehlo()
     mail.starttls()
 
-    mail.sendmail(fromEmail, ",".join(toList), msg.as_string())
+    mail.sendmail(fromEmail, toList, msg.as_string())
     mail.quit()
 
 def sendMailWithTextAttachment(fromEmail,toList,subj,msgText,msgAttachTxt,attachFileName="attach.txt"):
@@ -975,7 +974,7 @@ def sendMailWithTextAttachment(fromEmail,toList,subj,msgText,msgAttachTxt,attach
     mail.ehlo()
     mail.starttls()
 
-    mail.sendmail(fromEmail, ",".join(toList), msg.as_string())
+    mail.sendmail(fromEmail, toList, msg.as_string())
     mail.quit()
 
 def ldapConnect():

--- a/locker_services/utils.py
+++ b/locker_services/utils.py
@@ -548,7 +548,8 @@ def getInstanceTypes(ami_id=None):
     if cacheReadObj is not None:
         ret_instance_types = cacheReadObj[0]
         inst_type_name_to_desc = cacheReadObj[1]
-        return (ret_instance_types,inst_type_name_to_desc)
+        inst_type_name_to_price = cacheReadObj[2] if len(cacheReadObj) > 2 else {}
+        return (ret_instance_types,inst_type_name_to_desc,inst_type_name_to_price)
 
     checkCommonInstTypesList = config.EC2_COMMON_INST_TYPES
     checkCommonInstTypesSet = set(checkCommonInstTypesList)
@@ -557,6 +558,7 @@ def getInstanceTypes(ami_id=None):
     other_instance_types = []
     ret_instance_types = []
     inst_type_name_to_desc = {}
+    inst_type_name_to_price = {}
 
     (SubnetId,SecurityGroupId,KeyName) = getNewEc2Params()
 
@@ -582,6 +584,10 @@ def getInstanceTypes(ami_id=None):
                     instTypePrice = instTypePricingInfo['price']
                 if instTypePricingInfo is not None and 'unit' in instTypePricingInfo:
                     instTypePriceUnit = instTypePricingInfo['unit']
+            try:
+                inst_type_name_to_price[instTypeName] = float(instTypePrice)
+            except (ValueError, TypeError):
+                inst_type_name_to_price[instTypeName] = None
             defVirtCpus = curInstTypeRec["VCpuInfo"]["DefaultVCpus"]
             memory = int(curInstTypeRec["MemoryInfo"]["SizeInMiB"])
             if memory >= 1024:
@@ -602,10 +608,10 @@ def getInstanceTypes(ami_id=None):
             common_instance_types.append(common_instance_types_found[curInstType])
     ret_instance_types = ["---Commonly-Used-Types---"] + common_instance_types + ["---Other-Types---"] + other_instance_types
 
-    cacheWriteObj = [ret_instance_types,inst_type_name_to_desc]
+    cacheWriteObj = [ret_instance_types,inst_type_name_to_desc,inst_type_name_to_price]
     writeObjToJsonCacheFile(cacheWriteObj,instanceTypesCacheFileLoc)
 
-    return(ret_instance_types,inst_type_name_to_desc)
+    return(ret_instance_types,inst_type_name_to_desc,inst_type_name_to_price)
 
 def getLockerInstances(creator=None):
 

--- a/locker_services/utils.py
+++ b/locker_services/utils.py
@@ -806,6 +806,10 @@ def startEc2(aws_region='us-east-1',root_disk_size=100,ec2_instance_type='t2.mic
                 {
                     'ResourceType': 'instance',
                     'Tags': tagsArr
+                },
+                {
+                    'ResourceType': 'volume',
+                    'Tags': tagsArr
                 }
             ]
         )

--- a/locker_services/utils.py
+++ b/locker_services/utils.py
@@ -840,6 +840,75 @@ def startEc2(aws_region='us-east-1',root_disk_size=100,ec2_instance_type='t2.mic
 
     return(response,remoteHostname)
 
+def getEc2InstanceDetails(instanceId):
+    """Retrieves current instance state, type, tags, and root volume size."""
+    try:
+        ec2 = boto3.resource('ec2')
+        instance = ec2.Instance(instanceId)
+
+        state = instance.state['Name']
+        instance_type = instance.instance_type
+
+        tags = {}
+        if instance.tags:
+            for tag in instance.tags:
+                tags[tag['Key']] = tag['Value']
+
+        # Get root volume size (root device is /dev/xvda)
+        root_volume_id = None
+        root_volume_size = None
+        if instance.block_device_mappings:
+            for bdm in instance.block_device_mappings:
+                if bdm['DeviceName'] == '/dev/xvda':
+                    root_volume_id = bdm['Ebs']['VolumeId']
+                    volume = ec2.Volume(root_volume_id)
+                    root_volume_size = volume.size
+                    break
+
+        return {
+            'success': True,
+            'state': state,
+            'instance_type': instance_type,
+            'tags': tags,
+            'root_volume_id': root_volume_id,
+            'root_volume_size': root_volume_size
+        }
+    except Exception as e:
+        return {'success': False, 'error_msg': str(e)}
+
+def updateEc2Tags(instanceId, tags):
+    """Updates tags on an EC2 instance. tags is a list of {'Key': ..., 'Value': ...} dicts."""
+    try:
+        ec2 = boto3.resource('ec2')
+        ec2.create_tags(Resources=[instanceId], Tags=tags)
+        return {'success': True}
+    except Exception as e:
+        return {'success': False, 'error_msg': str(e)}
+
+def modifyEc2InstanceType(instanceId, newInstanceType):
+    """Modifies the instance type of a stopped EC2 instance."""
+    try:
+        client = boto3.client('ec2')
+        client.modify_instance_attribute(
+            InstanceId=instanceId,
+            InstanceType={'Value': newInstanceType}
+        )
+        return {'success': True}
+    except Exception as e:
+        return {'success': False, 'error_msg': str(e)}
+
+def modifyEc2VolumeSize(volumeId, newSizeGb):
+    """Modifies the size of an EBS volume. Size can only be increased. AWS enforces a 6h cooldown between modifications."""
+    try:
+        client = boto3.client('ec2')
+        client.modify_volume(
+            VolumeId=volumeId,
+            Size=int(newSizeGb)
+        )
+        return {'success': True}
+    except Exception as e:
+        return {'success': False, 'error_msg': str(e)}
+
 def sendMailSMUser(fromEmail,subj,msgHtml):
 
     http_smuser = os.environ.get(config.SERVER_USER_ENV_VAR_NAME)


### PR DESCRIPTION
## Summary
- Add an "Edit" link in the EC2 portal for non-terminated instances, allowing users to modify instance type, description, and root disk size in-place without terminating and recreating
- Disable EC2 creation tabs and show a warning banner when the user has reached their server limit
- Fix `sendMail` and `sendMailWithTextAttachment` to pass the recipient list as a list instead of a comma-joined string, matching what `smtplib.sendmail()` expects
- Require users to provide a written justification when selecting instance types above a configurable cost threshold (`LARGE_INSTANCE_COST_THRESHOLD`); justification is stored as an EC2 tag and emailed to admins
- Show a user-friendly error when volume resize fails due to AWS's 6-hour optimization cooldown, with the full AWS error behind a collapsible toggle
- Rewrite EC2/Locker launch success messages with clear headings, labeled server details, and named action links (Open Locker, Server Portal, Terminate Server) instead of ambiguous "here" links
- Open external links (Locker, SSH) in new tabs; use full URLs so links work in email notifications
- Add configurable Jira issue collector buttons and a "Get help" support email link in a subtle support bar on all pages; fully config-driven with zero footprint when unconfigured

## Test plan
- [x] Edit an EC2 instance's type, description, and disk size; verify changes apply
- [x] Select a high-cost instance type and verify justification prompt appears; confirm tag and email are sent
- [x] Attempt a volume resize shortly after a previous resize; verify friendly cooldown error with collapsible details
- [x] Launch EC2+Locker and verify the new success message format with working links
- [x] Verify email notifications contain full URLs that resolve correctly
- [x] Confirm Locker/SSH links on the portal open in new tabs; Server Portal/Terminate stay in same tab
- [x] Verify server limit warning appears when at capacity and creation tabs are disabled
- [x] Configure `jira_collectors` and `support_email` in config.yml; verify buttons render on all pages
- [x] Remove both config values; verify no extra HTML/CSS/JS in page source