### PR TITLE
Apply server limit to admins with override checkbox

### DIFF
--- a/locker_services/locker.cgi
+++ b/locker_services/locker.cgi
@@ -455,11 +455,19 @@ def new_ec2_func(exec_exit=True):
    if stage == 'exec':
 
       # Check server limit
-      if smuser not in locker_config.ADMIN_USERNAME:
-         existing_instances = utils.getLockerInstances(creator=smuser)
-         non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
-         max_servers = locker_config.MAX_SERVERS_PER_USER
-         if len(non_terminated) >= max_servers:
+      existing_instances = utils.getLockerInstances(creator=smuser)
+      non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
+      max_servers = locker_config.MAX_SERVERS_PER_USER
+      if len(non_terminated) >= max_servers:
+         if smuser in locker_config.ADMIN_USERNAME:
+            override = arguments.getvalue('override_server_limit')
+            if not override:
+               cgi_exit(
+                  f"<b>Error</b>: You already have {len(non_terminated)} server(s) (limit is {max_servers}). "
+                  f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> or use the admin override checkbox before creating a new one.",
+                  config_btn='new_ec2_btn'
+               )
+         else:
             cgi_exit(
                f"<b>Error</b>: You already have {len(non_terminated)} server(s) (limit is {max_servers}). "
                f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one.",
@@ -842,18 +850,19 @@ def cgi_exit(errormsg,config_btn=''):
    template = env.get_template('res_mesg.html')
    config['msg'] = errormsg
    config['config_btn'] = config_btn
-   # Check server limit for tab display (non-admin users only)
+   # Check server limit for tab display
    smuser_limit_check = utils.getEnvVar(locker_config.SERVER_USER_ENV_VAR_NAME)
-   if smuser_limit_check not in locker_config.ADMIN_USERNAME:
-      existing_instances = utils.getLockerInstances(creator=smuser_limit_check)
-      non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
-      max_servers = locker_config.MAX_SERVERS_PER_USER
-      if len(non_terminated) >= max_servers:
-         config['at_server_limit'] = True
-         config['server_limit_msg'] = (
-            f"You have {len(non_terminated)} server(s) (limit is {max_servers}). "
-            f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one."
-         )
+   is_admin = smuser_limit_check in locker_config.ADMIN_USERNAME
+   config['is_admin'] = is_admin
+   existing_instances = utils.getLockerInstances(creator=smuser_limit_check)
+   non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
+   max_servers = locker_config.MAX_SERVERS_PER_USER
+   if len(non_terminated) >= max_servers:
+      config['at_server_limit'] = True
+      config['server_limit_msg'] = (
+         f"You have {len(non_terminated)} server(s) (limit is {max_servers}). "
+         f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one."
+      )
    # Pass Jira issue collectors and support email config to template (if configured)
    jira_collectors = getattr(locker_config, 'jira_collectors', None)
    if jira_collectors:
@@ -894,18 +903,19 @@ elif a == 'edit_ec2_instance':
 
 
 if config is not None and template is not None:
-   # Check server limit for tab display (non-admin users only)
+   # Check server limit for tab display
    smuser_limit_check = utils.getEnvVar(locker_config.SERVER_USER_ENV_VAR_NAME)
-   if smuser_limit_check not in locker_config.ADMIN_USERNAME:
-      existing_instances = utils.getLockerInstances(creator=smuser_limit_check)
-      non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
-      max_servers = locker_config.MAX_SERVERS_PER_USER
-      if len(non_terminated) >= max_servers:
-         config['at_server_limit'] = True
-         config['server_limit_msg'] = (
-            f"You have {len(non_terminated)} server(s) (limit is {max_servers}). "
-            f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one."
-         )
+   is_admin = smuser_limit_check in locker_config.ADMIN_USERNAME
+   config['is_admin'] = is_admin
+   existing_instances = utils.getLockerInstances(creator=smuser_limit_check)
+   non_terminated = [i for i in existing_instances if i['State']['Name'] != 'terminated']
+   max_servers = locker_config.MAX_SERVERS_PER_USER
+   if len(non_terminated) >= max_servers:
+      config['at_server_limit'] = True
+      config['server_limit_msg'] = (
+         f"You have {len(non_terminated)} server(s) (limit is {max_servers}). "
+         f"Please <a href='locker.cgi?a=ec2_portal'>terminate existing servers</a> before creating a new one."
+      )
    # Pass Jira issue collectors and support email config to template (if configured)
    jira_collectors = getattr(locker_config, 'jira_collectors', None)
    if jira_collectors:

--- a/locker_services/templates/base.html
+++ b/locker_services/templates/base.html
@@ -146,12 +146,12 @@
       <!-- See here: https://stackoverflow.com/questions/12912048/how-to-maintain-aspect-ratio-using-html-img-tag -->
       <li><img class="locker_services_image" src="/static/logo_services.jpg" alt="Locker Services" style="max-width:64px;max-height:64px;width:auto;height:auto" onclick="document.location='locker.cgi';"></img></li>
       <li><a id="ec2_portal_btn" class="btn btn-primary" href="locker.cgi?a=ec2_portal">Locker Server Portal</a></li>&nbsp;&nbsp;
-      {% if config.at_server_limit | default(false) %}
+      {% if config.at_server_limit | default(false) and not config.is_admin | default(false) %}
       <li style="cursor:not-allowed;"><a id="new_ec2_locker_btn" class="btn btn-primary disabled" title="Server limit reached">Locker on New Server</a></li>&nbsp;&nbsp;
       {% else %}
       <li><a id="new_ec2_locker_btn" class="btn btn-primary" href="locker.cgi?a=new_ec2_locker">Locker on New Server</a></li>&nbsp;&nbsp;
       {% endif %}
-      {% if config.at_server_limit | default(false) %}
+      {% if config.at_server_limit | default(false) and not config.is_admin | default(false) %}
       <li style="cursor:not-allowed;"><a id="new_ec2_btn" style="display:none;" class="OTHER_OPTS btn btn-primary disabled" title="Server limit reached">New Server</a></li>&nbsp;&nbsp;
       {% else %}
       <li><a id="new_ec2_btn" style="display:none;" class="OTHER_OPTS btn btn-primary" href="locker.cgi?a=new_ec2">New Server</a></li>&nbsp;&nbsp;
@@ -168,6 +168,9 @@
 <div class="alert alert-warning alert-dismissible" role="alert">
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   <b>Server limit reached:</b> {{ config.server_limit_msg | safe }}
+  {% if config.is_admin | default(false) %}
+  <br>As an admin, you can override this limit when creating a new server.
+  {% endif %}
 </div>
 {% endif %}
 

--- a/locker_services/templates/new_ec2.html
+++ b/locker_services/templates/new_ec2.html
@@ -74,6 +74,16 @@
     <label><input type="checkbox" name="ecr" {{ config.ecr }}> Pull from ECR? (requires AWS credentials)</label>
   </div>
   </span>
+  {% if config.at_server_limit | default(false) and config.is_admin | default(false) %}
+  <div class="form-group">
+    <div class="alert alert-warning">
+      <label>
+        <input type="checkbox" name="override_server_limit" value="1" required>
+        You have reached the server limit. As an admin, check this box to override the limit and create a new server.
+      </label>
+    </div>
+  </div>
+  {% endif %}
   <button type="submit" class="btn btn-default" name="start_ec2" id="start_ec2" value="set">Start New Server</button>
   <input type="hidden" name="a" value="new_ec2" />
   <input type="hidden" name="stage" value="exec" />

--- a/locker_services/templates/new_ec2_locker.html
+++ b/locker_services/templates/new_ec2_locker.html
@@ -77,6 +77,16 @@
     <label><input type="checkbox" name="ecr" {{ config.ecr }}> Pull from ECR? (requires AWS credentials)</label>
   </div>
   </span>
+  {% if config.at_server_limit | default(false) and config.is_admin | default(false) %}
+  <div class="form-group">
+    <div class="alert alert-warning">
+      <label>
+        <input type="checkbox" name="override_server_limit" value="1" required>
+        You have reached the server limit. As an admin, check this box to override the limit and create a new server.
+      </label>
+    </div>
+  </div>
+  {% endif %}
   <button type="submit" class="btn btn-default" name="start_ec2_locker" id="start_ec2_locker" value="set">Start Locker on New Server</button>
   <input type="hidden" name="a" value="new_ec2_locker" />
   <input type="hidden" name="stage" value="exec" />


### PR DESCRIPTION
## Summary
- Admins are no longer fully exempt from the `MAX_SERVERS_PER_USER` limit
- Admins see the same server limit warning as regular users, with a note that they can override
- Nav buttons remain enabled for admins at the limit so they can still access the creation form
- A required override checkbox appears on the EC2 creation form for admins at the limit
- Server-side enforcement blocks submission unless the override checkbox is checked

## Test plan
- [x] Verify non-admin users at the limit see disabled buttons and cannot create servers (unchanged behavior)
- [x] Verify non-admin users under the limit can create servers normally (unchanged behavior)
- [x] Verify admins under the limit can create servers normally with no override checkbox shown
- [x] Verify admins at the limit see the warning banner with admin override note
- [x] Verify admins at the limit have nav buttons still enabled
- [x] Verify the override checkbox appears on both "New Server" and "Locker on New Server" forms for admins at the limit
- [x] Verify admins cannot submit the form without checking the override checkbox
- [x] Verify admins can successfully create a server after checking the override checkbox